### PR TITLE
fix typo in 01_the_maching_learning_landscape

### DIFF
--- a/01_the_machine_learning_landscape.ipynb
+++ b/01_the_machine_learning_landscape.ipynb
@@ -58,7 +58,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "I also requires Scikit-Learn ≥ 1.5.2:"
+    "It also requires Scikit-Learn ≥ 1.5.2:"
    ]
   },
   {


### PR DESCRIPTION
Simple typo fix in markdown cell between code cells 1 and 2.