### PR TITLE
Fix stateful RNN text generation to preserve hidden states

### DIFF
--- a/14_nlp_with_rnns_and_attention.ipynb
+++ b/14_nlp_with_rnns_and_attention.ipynb
@@ -992,7 +992,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's try generating some text with our stateful RNN. We must reset the `hidden_states` every time we call the model:"
+    "Let's try generating some text with our stateful RNN. The `hidden_states` are reset once at the beginning, then preserved across character generation:"
    ]
   },
   {
@@ -1003,8 +1003,11 @@
    "source": [
     "def extend_text_with_stateful_rnn(model, text, n_chars=80, temperature=1):\n",
     "    model.hidden_states = None\n",
+    "    rnn_input = text\n",
     "    for _ in range(n_chars):\n",
-    "        text += next_char(model, text, temperature)\n",
+    "        char = next_char(model, rnn_input, temperature)\n",
+    "        text += char\n",
+    "        rnn_input = char\n",
     "    return text + \"…\""
    ]
   },
@@ -1045,7 +1048,7 @@
     }
    ],
    "source": [
-    "print(extend_text(stateful_model, \"To be or not to b\", temperature=0.4))"
+    "print(extend_text_with_stateful_rnn(stateful_model, \"To be or not to b\", temperature=0.4))"
    ]
   },
   {
@@ -1064,7 +1067,7 @@
     }
    ],
    "source": [
-    "print(extend_text(stateful_model, \"To be or not to b\", temperature=1))"
+    "print(extend_text_with_stateful_rnn(stateful_model, \"To be or not to b\", temperature=1))"
    ]
   },
   {


### PR DESCRIPTION
I think there might be a bug in the **extend_text_with_stateful_rnn()** function. I’m not sure if it was intentional or done for demonstration purposes, but currently the hidden states are **reset every time a character is generated**.
This effectively disables the stateful behavior of the RNN, as it cannot retain long-term context across generated characters.