### PR TITLE
Fix finite-difference gradient calculation after redefining f(v)Fix finite difference gradient code after redefining f as f(v)

### DIFF
--- a/10_neural_nets_with_pytorch.ipynb
+++ b/10_neural_nets_with_pytorch.ipynb
@@ -3439,12 +3439,13 @@
     }
    ],
    "source": [
-    "eps = 0.00005\n",
-    "df_dx = (f(x + eps, y) - f(x, y)) / eps\n",
-    "df_dy = (f(x, y + eps) - f(x, y)) / eps\n",
-    "\n",
-    "df_dx.item(), df_dy.item()"
-   ]
+     "eps = 0.00005\n",
+     "v0 = v.detach()\n",
+     "df_dx = (f(torch.tensor([v0[0] + eps, v0[1]])) - f(v0)) / eps\n",
+     "df_dy = (f(torch.tensor([v0[0], v0[1] + eps])) - f(v0)) / eps\n",
+     "\n",
+     "df_dx.item(), df_dy.item()"
+    ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
This PR fixes issue #9.

In the notebook, f(x, y) is defined first, but later f is redefined to take
a single vector v containing [x, y]. The finite-difference gradient section
still uses the scalar form f(x, y), causing a TypeError ("f() takes 1 positional
argument but 2 were given").

This fix updates the finite-difference code to call f(v) correctly by
constructing vector inputs. The numerical gradients now match the autograd
results.
