### PR TITLE
Add a note to address why we revert back to the original dataframe

### DIFF
--- a/02_end_to_end_machine_learning_project.ipynb
+++ b/02_end_to_end_machine_learning_project.ipynb
@@ -2213,6 +2213,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note: The above cell resets the housing dataframe, also removing the custom features we just added. We are doing this because, later in the chapter, we will build an automated 'transformation pipeline' to handle all these steps at once."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Data Cleaning"
    ]
   },


### PR DESCRIPTION
- Many beginners might face issues as to why the newly created features were removed. 
- This note will let new readers understand that the same features will be added again when the pipeline for transformations is created.