### PR TITLE
fix: handle datasets >= 4.0.0 with different loading path

### DIFF
--- a/14_nlp_with_rnns_and_attention.ipynb
+++ b/14_nlp_with_rnns_and_attention.ipynb
@@ -1257,7 +1257,7 @@
    "source": [
     "from datasets import load_dataset\n",
     "\n",
-    "imdb_dataset = load_dataset(\"imdb\")\n",
+    "imdb_dataset = load_dataset(\"stanfordnlp/imdb\")\n",
     "split = imdb_dataset[\"train\"].train_test_split(train_size=0.8, seed=42)\n",
     "imdb_train_set, imdb_valid_set = split[\"train\"], split[\"test\"]\n",
     "imdb_test_set = imdb_dataset[\"test\"]"


### PR DESCRIPTION
Updated the dataset path to work with the datasets version 4.0.0.